### PR TITLE
Let speak animations be optional

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -400,7 +400,7 @@ func validate_animations(animations_resource: ESCAnimationResource) -> void:
 		else:
 			_validate_animations_property_all_not_null(animations_resource.idles, "idles")
 
-		if animations_resource.speaks.size() != num_dir_angles:
+		if animations_resource.speaks.size() != 0 && animations_resource.speaks.size() != num_dir_angles:
 			_scene_warnings.append("%s animation angles specified but %s 'speaks' animation(s) given. [%s]" \
 				% [num_dir_angles, animations_resource.speaks.size(), _get_identifier_as_key_value()])
 		else:


### PR DESCRIPTION
I was following Escoria's step-by-step guide. It [says](https://docs.escoria-framework.org/en/devel/getting_started/step_by_step/2_create_player_character.html#telling-escoria-about-the-walkcycle) that the speak animations are optional:

> The Speak animations are optional and only required if your game needs them.

However, when I tried running the game without them, it crashed with the message `8 animation angles specified but 0 'speaks' animation(s) given`. I think it makes sense to do this validation only when any speak animations are defined, i.e. their number is greater than 0.