### PR TITLE
Fixed player not correctly initialized when movable but not selectable.

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_player.gd
+++ b/addons/escoria-core/game/core-scripts/esc_player.gd
@@ -18,7 +18,7 @@ func _init():
 
 # Ready function
 func _ready():
-	if selectable:
+	if selectable or is_movable:
 		._ready()
 	else:
 		tooltip_name = ""


### PR DESCRIPTION
Fixed player not correctly initialized when movable but not selectable.

I ran into the issue that when the player is movable, there is coe in the super _ready function which needs to be called. So this was my fix for it. Otherwise _movable will be null.